### PR TITLE
refactor spiders

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (nsreg-watcher-1)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nsreg-watcher-1.iml" filepath="$PROJECT_DIR$/.idea/nsreg-watcher-1.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nsreg-watcher-1.iml
+++ b/.idea/nsreg-watcher-1.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/grabber/nsreg/spiders/multi_site_spider1.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider1.py
@@ -1,0 +1,73 @@
+'''
+Наименования сайтов: ООО «101домен Регистрация Доменов», ООО «Аукцион доменов», ООО «Безопасный регистратор»,
+ООО «Быстрый Хостинг», ООО «Гига Хостинг», ООО «Городские Домены», ООО «Дата Плюс», ООО «Дата Сити», ООО «Дом Доменов»,
+ООО «Дом Хостинга», ООО «Доменные Сервисы», ООО «Доменный Мастер», ООО «Домены Плюс», ООО «Домены Хостинг»,
+ООО «ДОМЕНЫ.РУ», ООО «Домэйн Агент», ООО «Домэйн Груп», ООО «Зона Доменов», ООО «Изи Хостинг», ООО «Магазин Доменов»
+АО «Международный сетевой технический центр», ООО «Мир Доменов», ООО «Мир Хостинга», ООО «Мощный Хостинг»,
+ООО «Мультирег», ООО «НэтДата», ООО «Опен Домэйнс», ООО «Приват Домэйнс», ООО «Приват Хостинг», ООО «Проф Хостинг»,
+ООО «Регио», ООО «Регис», ООО «Регистр 1», ООО «Смарт Домэйнс», ООО «Техно Дата», ООО «Турбо Хостинг»,
+ООО «Фабрика Доменов», ООО «ФАЕРФОКС», ООО «Хостинг Парк», ООО «Хот Хостинг», ООО «Центр Доменов», ООО «Ю.РУ»
+
+Адреса сайтов: https://sidename.ru, https://domainauction.ru, https://www.safereg.ru, https://www.speedhosting.ru,
+https://www.gigahosting.ru, https://citydomains.ru, https://www.data-plus.ru, https://www.datacity.ru,
+https://domainhouse.ru, https://www.domhostinga.ru, https://domainservice.ru, https://domainmaster.ru,
+https://domainplus.ru, https://www.domainshosting.ru, https://domains.ru, https://domainagent.ru,
+https://domaingroup.ru, https://zonadomenov.ru, https://www.easyhosting.ru, https://domain.ru, https://mstci.ru,
+https://mirdomenov.ru, https://www.mirhostinga.ru, https://www.powerhosting.ru, https://www.multireg.ru,
+https://www.netdata.ru, https://opendomains.ru, https://privatedomains.ru, https://www.privatehosting.ru,
+https://www.profhosting.ru, https://www.regio.ru, https://www.regis.ru, http://registr1.ru, https://smartdomains.ru,
+https://www.technodata.ru, https://www.turbohosting.ru, http://domainfactory.ru, http://firefox.ru,
+https://www.hostingpark.ru, https://www.hothosting.ru, http://domaincenter.ru, http://yu.ru
+
+Пример запуска на 2 сайта: scrapy crawl nsreg_1_sites -a start_urls=https://sidename.ru/site/tariffs,
+https://domainauction.ru/site/tariffs -a allowed_domains=sidename.ru,domainauction.ru -a
+site_names=ООО «101домен Регистрация Доменов»,ООО «Аукцион доменов»
+
+'''
+
+import scrapy
+
+from ..items import NsregItem
+from ..utils import find_price
+
+
+REGEX_PATTERN = r"([0-9]+[.,\s])?руб"
+
+EMPTY_PRICE = {
+    'pricereg': None,
+    'priceprolong': None,
+    'pricechange': None,
+}
+
+PRICE_XPATHS = {
+    'pricereg': '/html/body/section/div/div/div/div[2]/div[1]/div[2]/span/text()',
+    'priceprolong': '/html/body/section/div/div/div/div[2]/div[2]/div[2]/span/text()',
+    'pricechange': '/html/body/section/div/div/div/div[2]/div[3]/div[2]/span/text()',
+}
+
+class MultiSiteSpider1(scrapy.Spider):
+    name = 'multi_site_spider1'
+
+    def __init__(self, start_urls=None, allowed_domains=None, site_names=None, *args, **kwargs):
+        super(MultiSiteSpider1, self).__init__(*args, **kwargs)
+        if start_urls is not None:
+            self.start_urls = start_urls.split(',')
+        if allowed_domains is not None:
+            self.allowed_domains = allowed_domains.split(',')
+        if site_names is not None:
+            self.site_names = site_names.split(',')
+        else:
+            self.site_names = ["ООО «101домен Регистрация Доменов»"] * len(self.start_urls)
+
+    def parse(self, response):
+        item = NsregItem()
+        url_index = self.start_urls.index(response.url)
+        item['name'] = self.site_names[url_index]
+        price = item.get('price', EMPTY_PRICE)
+
+        for price_key, xpath in PRICE_XPATHS.items():
+            price_value = response.xpath(xpath).get()
+            price[price_key] = find_price(REGEX_PATTERN, price_value)
+
+        item['price'] = price
+        yield item

--- a/src/grabber/nsreg/spiders/multi_site_spider2.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider2.py
@@ -1,0 +1,59 @@
+'''
+Наименования сайтов: ООО «БЕСТРЕГ», ООО «БИГРЕГ», ООО «ВЕБРЕГ», ООО «ДОМЕНСЕРВИС», ООО «ДОМЕНХОСТ», ООО «КЛИКРЕГ»,
+ООО «КЛИКХОСТ», ООО «Нетонлайн», ООО «Онлайнрег», ООО «ОПЕНРЕГ», ООО «ПРИМАХОСТ», ООО «РЕГ.РУ ДОМЕНЫ ХОСТИНГ»,
+ООО «Редрег», ООО «РЕНТЕР.РУ», ООО «ТЕЛЕБОРД», ООО «ТЕЛЕХОСТ», ООО «ТОПДОМЕН»
+
+Адреса сайтов: https://www.bestreg24.ru, login.php, https://www.bigreg24.ru, login.php,
+https://www.webreg24.ru, login.php, https://www.domenservice.ru, login.php, https://www.regdomainhost.ru, login.php,
+https://www.clickreg.ru, login.php, https://www.clickhost24.ru, login.php, https://www.neton-line.ru, login.php,
+https://www.online-reg.ru, login.php, https://www.open-reg.ru, login.php, https://www.prima-host.ru, login.php,
+http://www.regplanet.ru, https://www.red-reg.ru, https://www.sm-domains.ru, login.php, http://telebord24.ru,
+https://telehost24.ru, http://topdomenreg24.ru,
+
+'''
+
+
+import scrapy
+from ..items import NsregItem
+from ..utils import find_price
+
+REGEX_PATTERN = r"([0-9]+[.,\s])?руб"
+EMPTY_PRICE = {
+    'pricereg': None,
+    'priceprolong': None,
+    'pricechange': None,
+}
+
+
+class MultiSiteSpider2(scrapy.Spider):
+    name = 'multi_site_spider2'
+
+    def __init__(self, start_urls=None, allowed_domains=None, site_names=None, *args, **kwargs):
+        super(MultiSiteSpider2, self).__init__(*args, **kwargs)
+        self.start_urls = start_urls.split(',') if start_urls else []
+        self.allowed_domains = allowed_domains.split(',') if allowed_domains else []
+        self.site_names = site_names.split(',') if site_names else []
+
+    def parse(self, response):
+        for i, url in enumerate(self.start_urls):
+            pricereg = response.xpath(
+                '/html/body/div[1]/div[3]/article/section/table[1]/tr/td[1]/article[1]/div/table/tr[5]/td[2]/text()').get()
+            pricereg = find_price(REGEX_PATTERN, pricereg)
+
+            priceprolong = response.xpath(
+                '/html/body/div[1]/div[3]/article/section/table[1]/tr/td[1]/article[1]/div/table/tr[5]/td[3]/text()').get()
+            priceprolong = find_price(REGEX_PATTERN, priceprolong)
+
+            pricechange = response.xpath(
+                '/html/body/div[1]/div[3]/article/section/table[2]/tr/td[1]/article[2]/div/table/tr[10]/td[2]/text()').get()
+            pricechange = find_price(REGEX_PATTERN, pricechange)
+
+            item = NsregItem()
+            item['name'] = self.site_names[i]
+            price = item.get('price', EMPTY_PRICE)
+            price['pricereg'] = pricereg
+            price['priceprolong'] = priceprolong
+            price['pricechange'] = pricechange
+            item['price'] = price
+
+            yield item

--- a/src/grabber/nsreg/spiders/multi_site_spider3.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider3.py
@@ -1,0 +1,53 @@
+'''
+Наименования сайтов: ООО «БИТНЭЙМС», ООО «Бэтнеймс», ООО «КАПИТАЛЪ», ООО «НЕЙМБИТ», ООО «Пар», ООО «РЕГЕОН»,
+ООО «Регион», ООО «РОЯЛЬ», ООО «РУДИ», ООО «СМП №2»
+
+Адреса сайтов: https://bitnames.ru, https://betnames.ru, https://capnames.ru, https://namebit.ru, https://parpro.ru,
+http://regeon.ru,https://regiondomains.ru,https://royaldomains.ru,https://rudy.ru,https://tapereg.ru,
+
+'''
+
+import scrapy
+from ..items import NsregItem
+from ..utils import find_price_sub
+
+REGEX_PATTERN = r".*(\d+\s+\d+).*"
+EMPTY_PRICE = {
+    'pricereg': None,
+    'priceprolong': None,
+    'pricechange': None,
+}
+
+
+class MultiSiteSpider3(scrapy.Spider):
+    name = 'multi_site_spider3'
+
+    def __init__(self, start_urls=None, allowed_domains=None, site_names=None, *args, **kwargs):
+        super(MultiSiteSpider3, self).__init__(*args, **kwargs)
+        self.start_urls = start_urls.split(',') if start_urls else []
+        self.allowed_domains = allowed_domains.split(',') if allowed_domains else []
+        self.site_names = site_names.split(',') if site_names else []
+
+    def parse(self, response):
+        pricereg = response.xpath(
+            '/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[1]/div/div/div[2]/div/p[1]/text()').get()
+        pricereg = find_price_sub(REGEX_PATTERN, pricereg)
+
+        priceprolong = response.xpath(
+            '/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[2]/div/div/div[2]/div/p[1]/text()').get()
+        priceprolong = find_price_sub(REGEX_PATTERN, priceprolong)
+
+        pricechange = response.xpath(
+            '/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[3]/div/div/div[2]/div/p[1]/text()').get()
+        pricechange = find_price_sub(REGEX_PATTERN, pricechange)
+
+        for site_name in self.site_names:
+            item = NsregItem()
+            item['name'] = site_name
+            price = item.get('price', EMPTY_PRICE)
+            price['pricereg'] = pricereg
+            price['priceprolong'] = priceprolong
+            price['pricechange'] = pricechange
+            item['price'] = price
+
+            yield item

--- a/src/grabber/nsreg/spiders/multi_site_spider4.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider4.py
@@ -1,0 +1,54 @@
+'''
+Наименования сайтов: ООО «ДНС», ООО «ИТ», ООО «КЛАСТЕР», ООО «КОД», ООО «Мега», ООО «НФ МЕДИА», ООО «Облако»,
+ООО «Открытые коммуникации», ООО «ПОЧТА», ООО «ПРО», ООО «ПРОКСИ»
+
+Адреса сайтов: https://fastdns.ru, https://4it.ru, https://clustered.ru, https://thecode.ru, http://megahost.ru,
+http://openreg.ru,https://cloudy.ru,https://opencom.ru,https://startmail.ru,https://proprovider.ru,https://dproxy.ru,
+
+'''
+
+
+import scrapy
+from ..items import NsregItem
+from ..utils import find_price, find_price_withoutre
+
+REGEX_PATTERN = r"([0-9]+)\s+₽.*"
+EMPTY_PRICE = {
+    'pricereg': None,
+    'priceprolong': None,
+    'pricechange': None,
+}
+
+
+class MultiSiteSpider4(scrapy.Spider):
+    name = 'multi_site_spider4'
+
+    def __init__(self, start_urls=None, allowed_domains=None, site_names=None, *args, **kwargs):
+        super(MultiSiteSpider4, self).__init__(*args, **kwargs)
+        self.start_urls = start_urls.split(',') if start_urls else []
+        self.allowed_domains = allowed_domains.split(',') if allowed_domains else []
+        self.site_names = site_names.split(',') if site_names else []
+
+    def parse(self, response):
+        pricereg = response.xpath(
+            '/html/body/div[1]/div[4]/div/div[2]/div[3]/div/div/div/div[2]/div/div/div[1]/div/table/tbody/tr[2]/td[2]/div/p/text()').get()
+        pricereg = find_price(REGEX_PATTERN, pricereg)
+
+        priceprolong = response.xpath(
+            '/html/body/div[1]/div[4]/div/div[2]/div[3]/div/div/div/div[2]/div/div/div[1]/div/table/tbody/tr[3]/td[2]/div/p/text()').get()
+        priceprolong = find_price(REGEX_PATTERN, priceprolong)
+
+        pricechange = response.xpath(
+            '/html/body/div[1]/div[4]/div/div[2]/div[3]/div/div/div/div[2]/div/div/div[1]/div/table/tbody/tr[4]/td[2]/div/p/text()').get()
+        pricechange = find_price(REGEX_PATTERN, pricechange)
+
+        for site_name in self.site_names:
+            item = NsregItem()
+            item['name'] = site_name
+            price = item.get('price', EMPTY_PRICE)
+            price['pricereg'] = pricereg
+            price['priceprolong'] = priceprolong
+            price['pricechange'] = pricechange
+            item['price'] = price
+
+            yield item

--- a/src/grabber/nsreg/spiders/multi_site_spider5.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider5.py
@@ -1,0 +1,51 @@
+'''
+Наименования сайтов: ООО «Актив.Домэинс», ООО «Ардис», ООО «Домэинреселлер», ООО «Домэинс24», ООО «Приватнэймс»,
+ООО «РУ-ДОМЭИНС»
+
+Адреса сайтов: http://active.domains, https://ardis.ru, https://domainreseller.ru, https://domains24.ru,
+http://private-names.ru,https://ru-domains.ru,
+
+'''
+
+
+import scrapy
+from ..items import NsregItem
+from ..utils import find_price
+
+REGEX_PATTERN = r".*(([0-9]*[.,])?[0-9]{3}).*"
+EMPTY_PRICE = {
+    'pricereg': None,
+    'priceprolong': None,
+    'pricechange': None,
+}
+
+
+class MultiSiteSpider5(scrapy.Spider):
+    name = 'multi_site_spider5'
+
+    def __init__(self, start_urls=None, allowed_domains=None, site_names=None, *args, **kwargs):
+        super(MultiSiteSpider5, self).__init__(*args, **kwargs)
+        self.start_urls = start_urls.split(',') if start_urls else []
+        self.allowed_domains = allowed_domains.split(',') if allowed_domains else []
+        self.site_names = site_names.split(',') if site_names else []
+
+    def parse(self, response):
+        pricereg = response.xpath('//*[@id="show_domain"]/div/div/table/tbody/tr[1]/td[3]/a/text()').get()
+        pricereg = find_price(REGEX_PATTERN, pricereg)
+
+        priceprolong = response.xpath('//*[@id="show_domain"]/div/div/table/tbody/tr[1]/td[4]/a/text()').get()
+        priceprolong = find_price(REGEX_PATTERN, priceprolong)
+
+        pricechange = response.xpath('//*[@id="show_domain"]/div/div/table/tbody/tr[1]/td[5]/a/text()').get()
+        pricechange = find_price(REGEX_PATTERN, pricechange)
+
+        for site_name in self.site_names:
+            item = NsregItem()
+            item['name'] = site_name
+            price = item.get('price', EMPTY_PRICE)
+            price['pricereg'] = pricereg
+            price['priceprolong'] = priceprolong
+            price['pricechange'] = pricechange
+            item['price'] = price
+
+            yield item


### PR DESCRIPTION
Провёл дополнительный анализ регистраторов и в результате было высвлено 6 групп сайтов с идентичной вёрсткой.

В результате разработал 5 универсальных мультиспайдеров, каждый из которых обрабатывает группу одинаковых сайтов (а это порядка 70% из всех сайтов регистраторов).

В MultiSiteSpider1, если site_names не предоставлен, список имен сайтов будет заполнен дефолтным значением ООО «101домен Регистрация Доменов», и количество таких имен будет равно количеству start_urls.

В остальных, если site_names не предоставлен, список имен сайтов просто будет пустым.

Соотвественно, спайдеры, которые попадают в мультиспайдеры предлагаю удалить, а сайты, которые не попадают под мультиспайдеры предлагаю доработать (их порядка 25 штук).