### PR TITLE
fix getting site name

### DIFF
--- a/src/grabber/nsreg/base_site_spider.py
+++ b/src/grabber/nsreg/base_site_spider.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from urllib.parse import urlparse
 
 from .items import NsregItem
 
@@ -60,7 +61,9 @@ class BaseSpiderComponent:
         price_change = find_price(self.regex['price_change'], price_change)
 
         # Получение имя сайта
-        site_name = self.site_names[self.start_urls.index(response.url)]
+        start_urls_netloc = [urlparse(url).netloc for url in self.start_urls]
+        response_url_netloc = urlparse(response.url).netloc
+        site_name = self.site_names[start_urls_netloc.index(response_url_netloc)]
 
         # Создание элемента данных и заполнение его информацией
         item = NsregItem()


### PR DESCRIPTION
Урлы из response.url и start_urls не всегда точно совпадают из-за разницы в схеме (http, https) и наличия/отсутствия конченого слеша. Тогда имя сайта не получится найти по индексу в массиве. Сделал экстракцию имени домена перед поиском. Можно поправить все данные в start_urls, но это долго.