### PR TITLE
Add space removal in find_price

### DIFF
--- a/src/grabber/nsreg/base_site_spider.py
+++ b/src/grabber/nsreg/base_site_spider.py
@@ -20,6 +20,10 @@ def find_price(re_pattern, price):
         # Применяем регулярное выражение к строке
         if m := re.match(re_pattern, price):
             price = m.group(1)
+
+            # Удаляем пробельные символы из строки
+            price = re.sub(r'\s', '', price)
+
     price = f'{float(price)}'
     logging.info('price = %s', price)
 


### PR DESCRIPTION
Добавил строчку с удалением пробелов в функции **find_price**, т.к мне кажется, что это лучший вариант решения проблемы с пробелами внутри строки.
Т.к используется метод *sub* из регулярок, то он удалит любые пробельные символы, в т.ч и юникодовские.
Вариант с **translate** из *xpath* не всегда работает, т.к в строке могут находиться и юникодовские пробелы типа **"\xa0"**, так и обычные " ". Такой случай оказался в **capnames.ru**
Плюс такой вариант не должен ломать случаи, когда мы в регулярке ищем пробел, т.к иногда это лучший способ найти цену на сайте. Получаем цену с пробелом из html и затем уже find_price приводит её в порядок.
Спайдеры, где используется translate, должны остаться исправными