### PR TITLE
Переписан a100.ru с BaseSpiderComponent, удален https:// из allowed_domains (www.regeon.ru)

### DIFF
--- a/src/grabber/nsreg/spiders/multi_site_spider3.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider3.py
@@ -1,12 +1,9 @@
 """
-Наименования сайтов: ООО «А100», ООО «БИТНЭЙМС», ООО «Бэтнеймс», ООО «Пар», ООО «РЕГЕОН», ООО «Регион»,
+Наименования сайтов: ООО «БИТНЭЙМС», ООО «Бэтнеймс», ООО «Пар», ООО «РЕГЕОН», ООО «Регион»,
  ООО «СМП №2»
 
-Адреса сайтов: https://a100.ru, https://bitnames.ru, https://betnames.ru, https://parpro.ru,
+Адреса сайтов: https://bitnames.ru, https://betnames.ru, https://parpro.ru,
 http://regeon.ru, https://regiondomains.ru, https://tapereg.ru,
-
-ООО «А100» закомментирован, т.к. есть подозрение, что он не подходит под данную
-группу
 
 """
 
@@ -19,7 +16,6 @@ class MultiSiteSpider3(scrapy.Spider):
     name = 'multi_site_spider3'
 
     start_urls = (
-        # 'https://a100.ru/#overlappable',
         'https://bitnames.ru/#features-2',
         'https://betnames.ru/#features-2',
         'https://parpro.ru/#features-2',
@@ -28,16 +24,14 @@ class MultiSiteSpider3(scrapy.Spider):
         'https://tapereg.ru/#features-2'
     )
     allowed_domains = (
-        # 'a100.ru',
         'bitnames.ru',
         'betnames.ru',
         'parpro.ru',
-        'http://regeon.ru',
+        'regeon.ru',
         'regiondomains.ru',
         'tapereg.ru'
     )
     site_names = (
-        # 'ООО «А100»',
         'ООО «БИТНЭЙМС»',
         'ООО «Бэтнеймс»',
         'ООО «Пар»',

--- a/src/grabber/nsreg/spiders/nsreg_a100.py
+++ b/src/grabber/nsreg/spiders/nsreg_a100.py
@@ -1,42 +1,29 @@
 # -*- coding: utf-8 -*-
 import scrapy
-from nsreg.items import NsregItem
 
-from ..utils import find_price_sub
-
-
-REGEX_PATTERN = r".*(\d+\s+\d+).*"
-EMPTY_PRICE = {
-    'price_reg': None,
-    'price_prolong': None,
-    'price_change': None,
-}
+from ..base_site_spider import BaseSpiderComponent
 
 
 class Nsreg_ad100Spider(scrapy.Spider):
     name = 'nsreg_a100'
     allowed_domains = ['a100.ru']
     start_urls = ['https://a100.ru/#overlappable']
+    site_names = ("ООО «А100»",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.component = BaseSpiderComponent(
+            start_urls=self.start_urls,
+            allowed_domains=self.allowed_domains,
+            site_names=self.site_names,
+            regex=r".*?(\d+).*",
+            path={
+                'price_reg':        'translate(/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[1]/div/div/div[2]/div/p[1]/text(), " ", "")',
+                'price_prolong':    'translate(/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[2]/div/div/div[2]/div/p[1]/text(), " ", "")',
+                'price_change':     'translate(/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[3]/div/div/div[2]/div/p[1]/text(), " ", "")'
+            }
+        )
 
     def parse(self, response):
-        price_reg = response.xpath(
-            '/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[1]/div/div/div[2]/div/p[1]/text()').get()
-        price_reg = find_price_sub(REGEX_PATTERN, price_reg)
-
-        price_prolong = response.xpath(
-            '/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[2]/div/div/div[2]/div/p[1]/text()').get()
-        price_prolong = find_price_sub(REGEX_PATTERN, price_prolong)
-
-        price_change = response.xpath(
-            '/html/body/div[1]/div[2]/div/div/div[1]/div/div/div/div[3]/div/div/div[2]/div/p[1]/text()').get()
-        price_change = find_price_sub(REGEX_PATTERN, price_change)
-
-        item = NsregItem()
-        item['name'] = "ООО «А100»"
-        price = item.get('price', EMPTY_PRICE)
-        price['price_reg'] = price_reg
-        price['price_prolong'] = price_prolong
-        price['price_change'] = price_change
-        item['price'] = price
-
-        yield item
+        return self.component.parse(response)

--- a/src/grabber/nsreg/spiders/nsreg_a100.py
+++ b/src/grabber/nsreg/spiders/nsreg_a100.py
@@ -9,6 +9,10 @@ class Nsreg_ad100Spider(scrapy.Spider):
     allowed_domains = ['a100.ru']
     start_urls = ['https://a100.ru/#overlappable']
     site_names = ("ООО «А100»",)
+    custom_settings = {
+        'DOWNLOAD_DELAY': 3,
+        'RANDOMIZE_DOWNLOAD_DELAY': False
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Заобдно убрал **https://** в **allowed_domains** убирает warning:

> 2024-01-18 10:34:30 [py.warnings] WARNING: /home/bob/code/nsreg-rudy/nsreg-watcher/env/lib/python3.10/site-packages/scrapy/spidermiddlewares/offsite.py:74: URLWarning: allowed_domains accepts only domains, not URLs. Ignoring URL entry http://regeon.ru in allowed_domains.
  warnings.warn(message, URLWarning)

Добавил задержку спайдера^ 
`    custom_settings = {
        'DOWNLOAD_DELAY': 3,
        'RANDOMIZE_DOWNLOAD_DELAY': False
        }`
убирает проблему Connection Refused(#240) 
