### PR TITLE
Fix TypeError... from grabeber_logs, removed https:// prefix from allowed_domains

### DIFF
--- a/src/grabber/nsreg/spiders/multi_site_spider1.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider1.py
@@ -53,20 +53,20 @@ class MultiSiteSpider1(scrapy.Spider):
         'http://domaincenter.ru/site/tariffs', 'http://yu.ru/site/tariffs'
     )
     allowed_domains = (
-        'https://domainauction.ru', 'https://www.safereg.ru',
-        'https://www.speedhosting.ru', 'https://www.gigahosting.ru', 'https://citydomains.ru',
-        'https://www.data-plus.ru', 'https://www.datacity.ru', 'https://domainhouse.ru',
-        'https://www.domhostinga.ru', 'https://domainservice.ru', 'https://domainmaster.ru',
-        'https://domainplus.ru', 'https://www.domainshosting.ru', 'https://domains.ru',
-        'https://domainagent.ru', 'https://domaingroup.ru', 'https://zonadomenov.ru',
-        'https://www.easyhosting.ru', 'https://domain.ru', 'https://mstci.ru', 'https://mirdomenov.ru',
-        'https://www.mirhostinga.ru', 'https://www.powerhosting.ru', 'https://www.multireg.ru',
-        'https://www.netdata.ru', 'https://opendomains.ru', 'https://privatedomains.ru',
-        'https://www.privatehosting.ru', 'https://www.profhosting.ru', 'https://www.regio.ru',
-        'https://www.regis.ru', 'http://registr1.ru', 'https://smartdomains.ru', 'https://www.technodata.ru',
-        'https://www.turbohosting.ru', 'http://domainfactory.ru', 'http://firefox.ru',
-        'https://www.hostingpark.ru', 'https://www.hothosting.ru', 'http://domaincenter.ru', 'http://yu.ru'
-    ),
+        'domainauction.ru', 'www.safereg.ru',
+        'www.speedhosting.ru', 'www.gigahosting.ru', 'citydomains.ru',
+        'www.data-plus.ru', 'www.datacity.ru', 'domainhouse.ru',
+        'www.domhostinga.ru', 'domainservice.ru', 'domainmaster.ru',
+        'domainplus.ru', 'www.domainshosting.ru', 'domains.ru',
+        'domainagent.ru', 'domaingroup.ru', 'zonadomenov.ru',
+        'www.easyhosting.ru', 'domain.ru', 'mstci.ru', 'mirdomenov.ru',
+        'www.mirhostinga.ru', 'www.powerhosting.ru', 'www.multireg.ru',
+        'www.netdata.ru', 'opendomains.ru', 'privatedomains.ru',
+        'www.privatehosting.ru', 'www.profhosting.ru', 'www.regio.ru',
+        'www.regis.ru', 'registr1.ru', 'smartdomains.ru', 'www.technodata.ru',
+        'www.turbohosting.ru', 'domainfactory.ru', 'firefox.ru',
+        'www.hostingpark.ru', 'www.hothosting.ru', 'domaincenter.ru', 'yu.ru'
+    )
     site_names = (
         'ООО «Аукцион доменов»', 'ООО «Безопасный регистратор»',
         'ООО «Быстрый Хостинг»', 'ООО «Гига Хостинг»', 'ООО «Городские Домены»', 'ООО «Дата Плюс»',

--- a/src/grabber/nsreg/spiders/multi_site_spider2.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider2.py
@@ -38,23 +38,23 @@ class MultiSiteSpider2(scrapy.Spider):
         'http://topdomenreg24.ru/price'
     )
     allowed_domains = (
-        'https://www.regdomainhost.ru/',
-        'https://www.bestreg24.ru',
-        'https://www.bigreg24.ru',
-        'https://www.webreg24.ru',
-        'https://www.domenservice.ru',
-        'https://www.clickreg.ru',
-        'https://www.clickhost24.ru',
-        'https://www.neton-line.ru',
-        'https://www.online-reg.ru',
-        'https://www.open-reg.ru',
-        'https://www.prima-host.ru',
-        'https://www.red-reg.ru',
-        'https://www.sm-domains.ru',
-        'http://telebord24.ru',
-        'https://telehost24.ru',
-        'http://topdomenreg24.ru'
-    ),
+        'www.regdomainhost.ru',
+        'www.bestreg24.ru',
+        'www.bigreg24.ru',
+        'www.webreg24.ru',
+        'www.domenservice.ru',
+        'www.clickreg.ru',
+        'www.clickhost24.ru',
+        'www.neton-line.ru',
+        'www.online-reg.ru',
+        'www.open-reg.ru',
+        'www.prima-host.ru',
+        'www.red-reg.ru',
+        'www.sm-domains.ru',
+        'telebord24.ru',
+        'telehost24.ru',
+        'topdomenreg24.ru'
+    )
     site_names = (
         'ООО «ДОМЕНХОСТ»',
         'ООО «БЕСТРЕГ»',

--- a/src/grabber/nsreg/spiders/multi_site_spider4.py
+++ b/src/grabber/nsreg/spiders/multi_site_spider4.py
@@ -1,12 +1,9 @@
 """
-Наименования сайтов: ООО «ДНС», ООО «ИТ», ООО «КЛАСТЕР», ООО «КОД», ООО «Мега», ООО «НФ МЕДИА», ООО «Облако»,
-ООО «Открытые коммуникации», ООО «ПОЧТА», ООО «ПРО», ООО «ПРОКСИ»
+Наименования сайтов: ООО «ДНС», ООО «ИТ», ООО «КЛАСТЕР», ООО «КОД», ООО «Мега», ООО «Облако»,
+ООО «ПОЧТА», ООО «ПРО», ООО «ПРОКСИ»
 
 Адреса сайтов: https://fastdns.ru, https://4it.ru, https://clustered.ru, https://thecode.ru, http://megahost.ru,
-http://openreg.ru,https://cloudy.ru,https://opencom.ru,https://startmail.ru,https://proprovider.ru,https://dproxy.ru,
-
-ООО «НФ МЕДИА» и  ООО «Открытые коммуникации» закомментированы, т.к. есть подозрение, что они не подходят под данную
-группу
+https://cloudy.ru,https://startmail.ru,https://proprovider.ru,https://dproxy.ru,
 
 """
 
@@ -24,35 +21,29 @@ class MultiSiteSpider4(scrapy.Spider):
         'https://clustered.ru/#price',
         'https://thecode.ru/#price',
         'http://megahost.ru/#price',
-        # 'http://openreg.ru/#price',
         'https://cloudy.ru/#price',
-        # 'https://opencom.ru/#price',
         'https://startmail.ru/#price',
         'https://proprovider.ru/#price',
         'https://dproxy.ru/#price'
     )
     allowed_domains = (
-        'https://fastdns.ru',
-        'https://4it.ru',
-        'https://clustered.ru',
-        'https://thecode.ru',
-        'http://megahost.ru',
-        # 'http://openreg.ru',
-        'https://cloudy.ru',
-        # 'https://opencom.ru',
-        'https://startmail.ru',
-        'https://proprovider.ru',
-        'https://dproxy.ru'
-    ),
+        'fastdns.ru',
+        '4it.ru',
+        'clustered.ru',
+        'thecode.ru',
+        'megahost.ru',
+        'cloudy.ru',
+        'startmail.ru',
+        'proprovider.ru',
+        'dproxy.ru'
+    )
     site_names = (
         'ООО «ДНС»',
         'ООО «ИТ»',
         'ООО «КЛАСТЕР»',
         'ООО «КОД»',
         'ООО «Мега»',
-        # 'ООО «НФ МЕДИА»',
         'ООО «Облако»',
-        # 'ООО «Открытые коммуникации»',
         'ООО «ПОЧТА»',
         'ООО «ПРО»',
         'ООО «ПРОКСИ»'


### PR DESCRIPTION
Closes #238 

Проблема: 

> 2024-01-18 11:00:46 [scrapy.utils.signal] ERROR: Error caught on signal handler: <bound method OffsiteMiddleware.spider_opened of <scrapy.spidermiddlewares.offsite.OffsiteMiddleware object at 0x7f771cba6c20>>
Traceback (most recent call last):
File "/home/bob/code/nsreg-rudy/nsreg-watcher/env/lib/python3.10/site-packages/scrapy/utils/defer.py", line 348, in maybeDeferred_coro
result = f(*args, **kw)
File "/home/bob/code/nsreg-rudy/nsreg-watcher/env/lib/python3.10/site-packages/pydispatch/robustapply.py", line 55, in robustApply
return receiver(*arguments, **named)
File "/home/bob/code/nsreg-rudy/nsreg-watcher/env/lib/python3.10/site-packages/scrapy/spidermiddlewares/offsite.py", line 88, in spider_opened
self.host_regex = self.get_host_regex(spider)
File "/home/bob/code/nsreg-rudy/nsreg-watcher/env/lib/python3.10/site-packages/scrapy/spidermiddlewares/offsite.py", line 70, in get_host_regex
if url_pattern.match(domain):
TypeError: expected string or bytes-like object

Причина: запятая после allowed_domains в multi_site_spider(1,2,4):
![image](https://github.com/ecodomen/nsreg-watcher/assets/122154728/79dbcc31-3988-4639-a238-bbdd1bdc69cd)

Убрал http:// prefix из allowed_domains, чтобы не было warning во время индивидуального запуска спайдера.
> 2024-01-18 10:34:30 [py.warnings] WARNING: /home/bob/code/nsreg-rudy/nsreg-watcher/env/lib/python3.10/site-packages/scrapy/spidermiddlewares/offsite.py:74: URLWarning: allowed_domains accepts only domains, not URLs. Ignoring URL entry http://regeon.ru/ in allowed_domains.
warnings.warn(message, URLWarning)
