### PR TITLE
Fix/remove search by price reg

### DIFF
--- a/src/website/catalog/views.py
+++ b/src/website/catalog/views.py
@@ -32,8 +32,10 @@ def registrator_list(request):
         search = ''
 
     if search:
-        companies = Price.objects.filter(Q(registrator__name__icontains=search) | Q(
-            registrator__city__icontains=search))
+        companies = Price.objects.filter(
+            Q(registrator__name__icontains=search) |
+            Q(registrator__city__icontains=search)
+            )
     else:
         companies = Price.objects.filter()
 

--- a/src/website/catalog/views.py
+++ b/src/website/catalog/views.py
@@ -33,7 +33,7 @@ def registrator_list(request):
 
     if search:
         companies = Price.objects.filter(Q(registrator__name__icontains=search) | Q(
-            registrator__city__icontains=search) | Q(price_reg__icontains=search))
+            registrator__city__icontains=search))
     else:
         companies = Price.objects.filter()
 


### PR DESCRIPTION
Удалил поиск по цене. Теперь, если набрать в поиске "2", то появятся только регистраторы, у которых есть "2" в названии. Раньше еще и появлялись результаты, содержащие цифру в цене